### PR TITLE
Uniquify the automatically assigned object-ids for named script entries.

### DIFF
--- a/src/KnownCodes.hs
+++ b/src/KnownCodes.hs
@@ -11,7 +11,7 @@ code2RawCode :: Word16 -> Maybe Word16
 code2RawCode code = knownRawCodes V.!? fromIntegral code
 
 firstObjectCode :: Word16
-firstObjectCode = 4716 
+firstObjectCode = 1000
 
 lastObjectCode :: Word16
 lastObjectCode = fromIntegral $ V.length knownRawCodes - 1

--- a/src/TipToiYaml.hs
+++ b/src/TipToiYaml.hs
@@ -179,18 +179,18 @@ scriptCodes codes codeMap productId
 -- This would assign perfectly usable object codes, and would minimize the 
 -- probability of object code collisions between products, but sometimes 
 -- object codes would wrap around from 16383 to 1000 even for small projects 
--- which may be undesirable. We arbitrarily do not use the last 199 possible 
--- offsets to avoid a wrap around in object codes for projects with <= 200 
+-- which may be undesirable. We arbitrarily do not use the last 999 possible
+-- offsets to avoid a wrap around in object codes for projects with <= 1000
 -- object codes. This does not impose any limit on the number of object codes 
 -- per project. Every project can always use all 15384 object codes.
-    objectCodeOffsetMax = lastObjectCode - firstObjectCode - 199
+    objectCodeOffsetMax = lastObjectCode - firstObjectCode - 999
 
 -- Distribute the used object codes for different projects across the whole 
 -- range of usable object codes. We do this by multiplying the productId with 
 -- the golden ratio to achive a maximum distance between different projects, 
 -- indepedent of the total number of different projects.
--- 9385 = (16383-1000-199+1)*((sqrt(5)-1)/2)
-    objectCodeOffset = toWord16(rem (productId * 9385) (toWord32(objectCodeOffsetMax) + 1))
+-- 8890 = (16383-1000-999+1)*((sqrt(5)-1)/2)
+    objectCodeOffset = toWord16(rem (productId * 8890) (toWord32(objectCodeOffsetMax) + 1))
 
 -- objectCodes always contains _all_ possible object codes [firstObjectCode..lastObjectCode], 
 -- starting at firstObjectCode+objectCodeOffset and then wrapping around.


### PR DESCRIPTION
Problem:
Object-ids for named script entries used to be assigned from 4716 upwards.
This leads to projects which all share the first object-ids. The pen then
cannot detect when a book/product was not correctly activated and the
behavior (sounds etc) does not match the book.

Solution:
Use different object-ids for different projects as far as possible.
Different projects always use a different product id, so the starting
point of automatically assigned object ids is derived from the
product id.

The assignemnt is scattered across the range of valid object-ids in such
a way that the average distance (in terms of object-ids) between projects
is always maximized independent of the number of projects involved.