### PR TITLE
Do not use OIDs >= 15000.

### DIFF
--- a/src/KnownCodes.hs
+++ b/src/KnownCodes.hs
@@ -14,7 +14,10 @@ firstObjectCode :: Word16
 firstObjectCode = 1000
 
 lastObjectCode :: Word16
-lastObjectCode = fromIntegral $ V.length knownRawCodes - 1
+-- Empirically, the pen does not recognize OIDs >= 15000:
+lastObjectCode = 14999
+-- Last object code accoring to the known raw codes:
+-- lastObjectCode = fromIntegral $ V.length knownRawCodes - 1
 
 knownRawCodes :: V.Vector Word16
 knownRawCodes =

--- a/src/TipToiYaml.hs
+++ b/src/TipToiYaml.hs
@@ -178,19 +178,19 @@ scriptCodes codes codeMap productId
 --    objectCodeOffsetMax = lastObjectCode - firstObjectCode.
 -- This would assign perfectly usable object codes, and would minimize the 
 -- probability of object code collisions between products, but sometimes 
--- object codes would wrap around from 16383 to 1000 even for small projects 
+-- object codes would wrap around from 14999 to 1000 even for small projects 
 -- which may be undesirable. We arbitrarily do not use the last 999 possible
 -- offsets to avoid a wrap around in object codes for projects with <= 1000
 -- object codes. This does not impose any limit on the number of object codes 
--- per project. Every project can always use all 15384 object codes.
+-- per project. Every project can always use all 14000 object codes.
     objectCodeOffsetMax = lastObjectCode - firstObjectCode - 999
 
 -- Distribute the used object codes for different projects across the whole 
 -- range of usable object codes. We do this by multiplying the productId with 
 -- the golden ratio to achive a maximum distance between different projects, 
--- indepedent of the total number of different projects.
--- 8890 = (16383-1000-999+1)*((sqrt(5)-1)/2)
-    objectCodeOffset = toWord16(rem (productId * 8890) (toWord32(objectCodeOffsetMax) + 1))
+-- independent of the total number of different projects.
+-- 8035 = (14999-1000-999+1)*((sqrt(5)-1)/2)
+    objectCodeOffset = toWord16(rem (productId * 8035) (toWord32(objectCodeOffsetMax) + 1))
 
 -- objectCodes always contains _all_ possible object codes [firstObjectCode..lastObjectCode], 
 -- starting at firstObjectCode+objectCodeOffset and then wrapping around.


### PR DESCRIPTION
This is the clean variant of the fix. Removing the *.codes.yaml file (not suggested) will assign different OIDs than 1.4/1.5 and break all printed labels.