### PR TITLE
Use macOS speech synthesis

### DIFF
--- a/src/TextToSpeech.hs
+++ b/src/TextToSpeech.hs
@@ -51,12 +51,22 @@ espeak_contrib myDir lang tmp txt =
     l = case lang of
             Language s    -> s
 
+say :: Language -> FilePath -> String -> (String, [String])
+say lang tmp txt =
+   ("say", ["-o", tmp, "--data-format=LEF32@8000", "-v", l, txt])
+  where
+   l = case lang of
+           Language "en" -> "Alex"
+	   Language "de" -> "Anna"
+	   Language "fr" -> "Thomas"
+	   Language s    -> s
 
 engines :: FilePath -> Language -> FilePath -> String -> [(String, [String])]
 engines myDir l ft txt =
     [ pico l ft txt
     , espeak l ft txt
     , espeak_contrib myDir l ft txt
+    , say l ft txt
     ]
 
 oggenc :: FilePath -> FilePath -> (String, [String])

--- a/src/TextToSpeech.hs
+++ b/src/TextToSpeech.hs
@@ -59,7 +59,6 @@ say lang tmp txt =
            Language "en" -> "Alex"
            Language "de" -> "Anna"
            Language "fr" -> "Thomas"
-           Language s    -> s
 
 engines :: FilePath -> Language -> FilePath -> String -> [(String, [String])]
 engines myDir l ft txt =

--- a/src/TextToSpeech.hs
+++ b/src/TextToSpeech.hs
@@ -57,9 +57,9 @@ say lang tmp txt =
   where
    l = case lang of
            Language "en" -> "Alex"
-	   Language "de" -> "Anna"
-	   Language "fr" -> "Thomas"
-	   Language s    -> s
+           Language "de" -> "Anna"
+           Language "fr" -> "Thomas"
+           Language s    -> s
 
 engines :: FilePath -> Language -> FilePath -> String -> [(String, [String])]
 engines myDir l ft txt =


### PR DESCRIPTION
macOS supports speech synthesis to the built in voices with the `say` command. Based on the voice's name, the language can be chosen. The sample rate is set to 8000 which is high enough for the synthesized voice.

Tested this code on macOS 10.12.5 without problem. But I couldn't test it on a real Tiptoi pen yet.