### PR TITLE
Fix alignment issue in oid-table generation (issue #147)

### DIFF
--- a/src/OidTable.hs
+++ b/src/OidTable.hs
@@ -53,9 +53,9 @@ oidTable conf title entries | entriesPerPage < 1 = error "OID codes too large to
 
             forM_ (zip thisPage positions) $ \((e,mbi),p) -> do
                 withNewContext $ do
-                    applyMatrix $ translate  p
+                    applyMatrix $ translate  (align p)
                     forM_ mbi $ \i -> withNewContext $ do
-                        applyMatrix $ translate  (0 :+ (-imageHeight))
+                        applyMatrix $ translate  (0 :+ (-(fromIntegral imageHeightPx)/px))
                         applyMatrix $ scale (1/px) (1/px)
                         drawXObject i
                     withNewContext $ do
@@ -125,6 +125,9 @@ oidTable conf title entries | entriesPerPage < 1 = error "OID codes too large to
     px :: Double
     px = fromIntegral (cDPI conf) / 72
 
+    align :: Point -> Point
+    align pos = (fromIntegral (floor (realPart pos * px)) / px
+                 :+ (a4h - (fromIntegral (floor ((a4h - imagPart pos) * px)) / px)))
 
 calcPositions
     :: Double -- ^ total width


### PR DESCRIPTION
This should fix issue #147. When generating an oid-table, the OID codes are now embedded in the pdf in such a way that the pixels of the OID codes align with the pixels of the pdf rendered at the correct dpi.

Note that this may only work when printing on a4 sized paper.