### PR TITLE
Support docker for building tttool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM haskell:8.0.2
+
+COPY . /tmp/code
+
+WORKDIR /tmp/code
+
+RUN cabal update
+RUN cabal install --only-dependencies
+RUN cabal install --bindir=.
+
+FROM debian:stretch
+COPY --from=0 /tmp/code/tttool /usr/local/bin
+
+RUN apt-get update -y
+RUN apt-get install -y libgmp10 libgmp-dev
+
+ENTRYPOINT [ "/usr/local/bin/tttool" ]


### PR DESCRIPTION
I had a hard time getting tttool to build. It doesn't seem to be compatible with Haskell 8.4.3. In order to make building easier I created a Dockerfile that uses Haskell 8.0.2. Maybe it's useful to someone. You could also provide a docker container which builds automatically on Dockerhub whenever you push to master.