### PR TITLE
Support the equality-alias conditional operator 0xFFFC

### DIFF
--- a/src/GMEParser.hs
+++ b/src/GMEParser.hs
@@ -195,6 +195,7 @@ lineParser = begin
         [ (B.pack [0xF9,0xFF], Eq)
         , (B.pack [0xFA,0xFF], Gt)
         , (B.pack [0xFB,0xFF], Lt)
+        , (B.pack [0xFC,0xFF], EqAlias)
         , (B.pack [0xFD,0xFF], GEq)
         , (B.pack [0xFE,0xFF], LEq)
         , (B.pack [0xFF,0xFF], NEq)

--- a/src/GMERun.hs
+++ b/src/GMERun.hs
@@ -80,6 +80,7 @@ condTrue s (Cond v1 o v2) = value s v1 =?= value s v2
         GEq -> (>=)
         Gt  -> (>)
         LEq -> (<=)
+        EqAlias -> (==)
         Unknowncond _ -> \_ _ -> False
 
 value :: Ord r => PlayState r -> TVal r -> Word16

--- a/src/GMEWriter.hs
+++ b/src/GMEWriter.hs
@@ -307,6 +307,7 @@ putCondOp Lt  = mapM_ putWord8 [0xFB, 0xFF]
 putCondOp GEq = mapM_ putWord8 [0xFD, 0xFF]
 putCondOp LEq = mapM_ putWord8 [0xFE, 0xFF]
 putCondOp NEq = mapM_ putWord8 [0xFF, 0xFF]
+putCondOp EqAlias = mapM_ putWord8 [0xFC, 0xFF]
 putCondOp (Unknowncond b) = putBS b
 
 

--- a/src/PrettyPrint.hs
+++ b/src/PrettyPrint.hs
@@ -73,6 +73,7 @@ ppCondOp Lt              = "< "
 ppCondOp Gt              = "> "
 ppCondOp GEq             = ">="
 ppCondOp LEq             = "<="
+ppCondOp EqAlias         = "==" -- 0xFFFC, same comparison as 0xFFF9 in the firmware
 ppCondOp (Unknowncond b) = printf "?%s?" (prettyHex b)
 
 ppTVal :: Reg r => TVal r -> String

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -32,6 +32,11 @@ data CondOp
     | GEq
     | LEq
     | NEq
+    | EqAlias
+      -- ^ opcode 0xFFFC. The firmware treats it exactly like Eq (0xFFF9); it has not
+      --   been seen in GME files so far. Kept distinct so that re-writing a GME
+      --   preserves the original bytes. Any conditional opcode not listed here is
+      --   treated by the firmware as an unsatisfied (false) condition.
     | Unknowncond B.ByteString
     deriving (Eq)
 


### PR DESCRIPTION
The firmware accepts 0xFFFC as a comparison operator and treats it exactly like equality (0xFFF9). It has not been seen in any GME file so far. Parse it as its own EqAlias operator (rather than normalizing to Eq) so that re-writing a GME preserves the original bytes; it prints as "==" and the play simulator compares accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)