### PR TITLE
Record firmware knowledge in parser and writer comments

### DIFF
--- a/src/GMEParser.hs
+++ b/src/GMEParser.hs
@@ -139,6 +139,9 @@ indirections g1 prefix g2 =
 
 -- Parsers
 
+-- The script table starts with two 32-bit words holding the last and first OID code;
+-- the pen bounds-checks a tapped OID against them and reads the script offset from the
+-- table of 32-bit offsets that follows (one per OID in that range).
 getScripts :: SGet [(Word16, Maybe [Line ResReg])]
 getScripts = do
     last_code <- getWord16
@@ -191,6 +194,8 @@ lineParser = begin
         xs <- getArray getWord16 getWord16
         return $ Line offset conds cmds xs
 
+    -- This list is complete: the firmware knows no other comparison operators, and
+    -- treats any other opcode as an unsatisfied (false) condition.
     conditionals =
         [ (B.pack [0xF9,0xFF], Eq)
         , (B.pack [0xFA,0xFF], Gt)
@@ -292,7 +297,9 @@ getAudios rawXor = do
                    | otherwise = n_entries `div` 2
     decoded <- forM [0..n_entries'-1] $ \n -> do
         cypher x <$> indirectBS (show n)
-    -- pretend we read the rest too
+    -- The copy following the main table is the *additional media file table* (header
+    -- offset 0x0060): the pen's built-in games read their media through it, while the
+    -- play scripts use the main table. In all known files both tables are equal.
     unless (similarity == Absent) $ lookAhead $ getSeg "Audio table copy" $
         replicateM_ (fromIntegral n_entries') (getWord32 >> getWord32)
 
@@ -320,6 +327,8 @@ getXor = do
         [] -> error "Could not find magic hash"
         (x:_) -> return x
 
+-- The pen never verifies this checksum (when mounting a file it checks only the magic
+-- at 0x0008, the product id and the language) -- but tttool does.
 getChecksum :: SGet Word32
 getChecksum = do
     l <- getLength
@@ -451,6 +460,8 @@ getTipToiFile = getSegAt 0x00 "Header" $ do
     ttWelcome <- indirection "initial play lists" getPlayListList
 
     jumpTo 0x008C
+    -- One flag per media file; the pen consults it when playing a sample to suppress
+    -- playing the same one twice in a row (the firmware calls it "VoiceNumberNeedRep").
     ttMediaFlags <- maybeIndirection "Mediaflags" (getMediaFlags (length ttAudioFiles))
     ttBinaries1 <- fromMaybe [] <$> maybeIndirection "Binaries 1" getBinaries
     ttSpecialOIDs <- maybeIndirection "special symbols" getSpecials

--- a/src/GMERun.hs
+++ b/src/GMERun.hs
@@ -81,6 +81,7 @@ condTrue s (Cond v1 o v2) = value s v1 =?= value s v2
         Gt  -> (>)
         LEq -> (<=)
         EqAlias -> (==)
+        -- like the pen: an unknown comparison operator never holds
         Unknowncond _ -> \_ _ -> False
 
 value :: Ord r => PlayState r -> TVal r -> Word16

--- a/src/GMEWriter.hs
+++ b/src/GMEWriter.hs
@@ -103,6 +103,9 @@ putTipToiFile (TipToiFile {..}) = mdo
     putBS ttDate
     putBS ttLang
     putWord8 0
+    -- Note: the additional media file table offset (0x0060) is left at zero. The pen's
+    -- built-in games read their media through that table (the play scripts use the main
+    -- table at 0x0004), so assembled files with games may need it; see GME-Format.md.
     seek 0x0071 -- Just to be safe
     putWord32 ipllo
     seek 0x0094

--- a/src/Lint.hs
+++ b/src/Lint.hs
@@ -59,8 +59,8 @@ lintTipToi tt segments = do
 warnTipToi :: TipToiFile -> IO ()
 warnTipToi tt = do
     sequence_
-      [ printf "[Script %d line %d] Warning: More than 8 commands per line may cause problems\n"
-            c n
+      [ printf "[Script %d line %d] Warning: The pen executes only the first 8 commands of a line; the remaining %d will be ignored\n"
+            c n (length cmds - 8)
       | (c, Just lines) <- ttScripts tt
       , (n,Line _ _ cmds _) <- zip [(1::Int)..] lines
       , length cmds > 8


### PR DESCRIPTION
Notes from the firmware analysis (see GME-Format.md) at the places in the parser and writer they concern: the script-table prologue (last and first OID code, bounds-checked by the pen), the completeness of the conditional-operator list (anything else counts as unsatisfied, also noted in the play simulator), the audio table copy (the additional media file table, which the built-in games read their media through -- and which assemble currently leaves at zero), the media flag table (per-media "do not repeat twice in a row"), and the checksum (never verified by the pen).

The only behavioural change is a more precise lint warning: the pen executes only the first 8 commands of a script line, so say that (and how many commands are ignored) instead of "may cause problems".