### PR TITLE
Fix off-by-one when writing game-select menus

### DIFF
--- a/src/GMEWriter.hs
+++ b/src/GMEWriter.hs
@@ -206,7 +206,7 @@ putGame g = mdo
             putWord32 gse2
 
             gso <- getAddress $ putOidList gGameSelectOIDs
-            gs  <- getAddress $ putArray putWord16 $ map putWord16 gGameSelect
+            gs  <- getAddress $ putGameIdList gGameSelect
             gse1 <- getAddress $ putPlayListList gGameSelectErrors1
             gse2 <- getAddress $ putPlayListList gGameSelectErrors2
 


### PR DESCRIPTION
getGameIdList converts the file's 1-based game record ids to 0-based on read, and putGameIdList adds the 1 back -- but the Game8 writer bypassed putGameIdList and wrote the raw 0-based values. Every parse-write cycle of a GME with a game-select menu (game type 8) thus silently decremented the menu's target ids, corrupting the menu.

Found by comparing the decoded game tables of WWW Feuerwehr before and after a rewrite; with this fix the decode is identical.