### PR TITLE
Rename the game fields whose meaning is now established

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+ * The game fields whose meanings firmware analysis established got
+   speaking names in the YAML format and the `explain`/`games` output:
+   the find-all-targets flag is a boolean `allneeded`, `repeatoid` is
+   the prompt-replay control OID, type 6 gains `bonusearlyrounds`, and
+   subgames have `header`/`targetoids`/`decoyoids`/`alloids`. The nine
+   subgame playlists are now individual named fields (`announce`,
+   `correct`, `wrong`, `notingame`, `alreadyfound`, `hints`,
+   `roundcomplete`, `solution`) plus an optional `unusedplaylist` for
+   the never-read ninth.
+
  * New script commands `AT(m)` (arm the periodic script timer, opcode FE00)
    and `CT` (cancel it, opcode FEFF), and a new top-level YAML field `timer`
    for the timer script, which the pen runs whenever the armed timer fires

--- a/src/GMEParser.hs
+++ b/src/GMEParser.hs
@@ -381,14 +381,14 @@ getRealGame 253 = return Game253
 getRealGame gGameType = do
     gSubgameCount             <- getWord16
     gRounds                   <- getWord16
-    gUnknownC                 <- getIf (/=6) getWord16
+    gAllNeededC               <- getIf (/=6) getWord16
     gBonusSubgameCount        <- getIf (==6) getWord16
     gBonusRounds              <- getIf (==6) getWord16
     gBonusTarget              <- getIf (==6) getWord16
-    gUnknownI                 <- getIf (==6) getWord16
+    gAllNeededI               <- getIf (==6) getWord16
     gEarlyRounds              <- getWord16
-    gUnknownQ                 <- getIf (==6) getWord16
-    gRepeatLastMedia          <- getWord16
+    gBonusEarlyRounds         <- getIf (==6) getWord16
+    gRepeatOID                <- getWord16
     gUnknownX                 <- getWord16
     gUnknownW                 <- getWord16
     gUnknownV                 <- getWord16
@@ -402,6 +402,10 @@ getRealGame gGameType = do
     let subgameCount | gGameType == 6 = gSubgameCount + gBonusSubgameCount
                      | otherwise      = gSubgameCount
     gSubgames                 <- indirections (return subgameCount) "subgame-" getSubGame
+    -- the find-all-targets flag sits at word "c" in the common layout, but at
+    -- word "i" in the type-6 layout
+    let gAllNeeded | gGameType == 6 = gAllNeededI
+                   | otherwise      = gAllNeededC
     gTargetScores             <- if gGameType == 6 then replicateM 2 getWord16
                                                    else replicateM 10 getWord16
     gBonusTargetScores        <- getIf (==6) $ replicateM 8 getWord16

--- a/src/GMEWriter.hs
+++ b/src/GMEWriter.hs
@@ -133,10 +133,10 @@ putGame (Game6 {..}) = mdo
     putWord16 gBonusSubgameCount
     putWord16 gBonusRounds
     putWord16 gBonusTarget
-    putWord16 gUnknownI
+    putWord16 gAllNeeded
     putWord16 gEarlyRounds
-    putWord16 gUnknownQ
-    putWord16 gRepeatLastMedia
+    putWord16 gBonusEarlyRounds
+    putWord16 gRepeatOID
     putWord16 gUnknownX
     putWord16 gUnknownW
     putWord16 gUnknownV
@@ -178,9 +178,9 @@ putGame g = mdo
     putWord16 (gameType g)
     putWord16 (fromIntegral $ length (gSubgames g))
     putWord16 (gRounds g)
-    putWord16 (gUnknownC g)
+    putWord16 (gAllNeeded g)
     putWord16 (gEarlyRounds g)
-    putWord16 (gRepeatLastMedia g)
+    putWord16 (gRepeatOID g)
     putWord16 (gUnknownX g)
     putWord16 (gUnknownW g)
     putWord16 (gUnknownV g)
@@ -251,10 +251,10 @@ putOidList = putArray putWord16 . map putWord16
 
 putSubGame :: SubGame -> SPut
 putSubGame (SubGame {..}) = mdo
-    putBS sgUnknown
-    putArray putWord16 $ map putWord16 sgOids1
-    putArray putWord16 $ map putWord16 sgOids2
-    putArray putWord16 $ map putWord16 sgOids3
+    putBS sgHeader
+    putArray putWord16 $ map putWord16 sgTargetOids
+    putArray putWord16 $ map putWord16 sgDecoyOids
+    putArray putWord16 $ map putWord16 sgAllOids
     mapM_ putWord32 pll 
     pll  <- mapM (getAddress . putPlayListList) sgPlaylist
     return ()

--- a/src/PrettyPrint.hs
+++ b/src/PrettyPrint.hs
@@ -156,9 +156,9 @@ ppCommonGame :: Transscript -> Game -> String
 ppCommonGame t g =
     printf (unlines ["  type: %d",
                      "  rounds: %d",
-                     "  unknown (c): %d",
+                     "  all needed (c): %d",
                      "  early rounds: %d",
-                     "  repeat last media OID: %d",
+                     "  repeat OID: %d",
                      "  unknown (x): %d",
                      "  unknown (w): %d",
                      "  unknown (v): %d",
@@ -173,9 +173,9 @@ ppCommonGame t g =
                      ])
     (gameType g)
     (gRounds g)
-    (gUnknownC g)
+    (gAllNeeded g)
     (gEarlyRounds g)
-    (gRepeatLastMedia g)
+    (gRepeatOID g)
     (gUnknownX g) (gUnknownW g) (gUnknownV g)
     (ppPlayListList t (gStartPlayList g))
     (ppPlayListList t (gRoundEndPlayList g))
@@ -195,10 +195,10 @@ ppGame t (Game6 {..}) =
                      "  rounds: %d",
                      "  bonus rounds: %d",
                      "  rounds target: %d",
-                     "  unknown (i): %d",
+                     "  all needed (i): %d",
                      "  early rounds: %d",
-                     "  unknown (q): %d",
-                     "  repeat last media OID: %d",
+                     "  bonus early rounds (q): %d",
+                     "  repeat OID: %d",
                      "  unknown (x): %d",
                      "  unknown (w): %d",
                      "  unknown (v): %d",
@@ -220,10 +220,10 @@ ppGame t (Game6 {..}) =
     gRounds
     gBonusRounds
     gBonusTarget
-    gUnknownI
+    gAllNeeded
     gEarlyRounds
-    gUnknownQ
-    gRepeatLastMedia
+    gBonusEarlyRounds
+    gRepeatOID
     gUnknownX gUnknownW gUnknownV
     (ppPlayListList t gStartPlayList)
     (ppPlayListList t gRoundEndPlayList)
@@ -283,10 +283,10 @@ ppSubGames t = concatMap (uncurry (ppSubGame t)) . zip [0..]
 ppSubGame :: Transscript -> Int -> SubGame -> String
 ppSubGame t n (SubGame u oids1 oids2 oids3 plls) = printf (unlines
     [ "    Subgame %d:"
-    , "      u: %s"
-    , "      oids1: %s"
-    , "      oids2: %s"
-    , "      oids3: %s"
+    , "      header: %s"
+    , "      target oids: %s"
+    , "      decoy oids: %s"
+    , "      all oids: %s"
     , "      playlist: (%d)" , "%s"
     ])
     n

--- a/src/TipToiYaml.hs
+++ b/src/TipToiYaml.hs
@@ -121,9 +121,9 @@ type OIDListYaml = String
 data GameYaml = CommonGameYaml
         { gyGameType                 :: Word16
         , gyRounds                   :: Word16
-        , gyUnknownC                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -141,10 +141,10 @@ data GameYaml = CommonGameYaml
         , gyBonusSubgameCount        :: Word16
         , gyBonusRounds              :: Word16
         , gyBonusTarget              :: Word16
-        , gyUnknownI                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyUnknownQ                 :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyBonusEarlyRounds         :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -164,9 +164,9 @@ data GameYaml = CommonGameYaml
         }
     | Game7Yaml
         { gyRounds                   :: Word16
-        , gyUnknownC                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -182,9 +182,9 @@ data GameYaml = CommonGameYaml
         }
     | Game8Yaml
         { gyRounds                   :: Word16
-        , gyUnknownC                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -203,9 +203,9 @@ data GameYaml = CommonGameYaml
         }
     | Game9Yaml
         { gyRounds                   :: Word16
-        , gyUnknownC                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -221,9 +221,9 @@ data GameYaml = CommonGameYaml
         }
     | Game10Yaml
         { gyRounds                   :: Word16
-        , gyUnknownC                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -239,9 +239,9 @@ data GameYaml = CommonGameYaml
         }
     | Game16Yaml
         { gyRounds                   :: Word16
-        , gyUnknownC                 :: Word16
+        , gyAllNeeded                :: Bool
         , gyEarlyRounds              :: Word16
-        , gyRepeatLastMedia          :: Word16
+        , gyRepeatOID                :: Word16
         , gyUnknownX                 :: Word16
         , gyUnknownW                 :: Word16
         , gyUnknownV                 :: Word16
@@ -259,12 +259,24 @@ data GameYaml = CommonGameYaml
     | Game253Yaml
     deriving Generic
 
+-- The nine playlistlists of a subgame have fixed roles (see GME-Format.md);
+-- they are exposed as named YAML fields. The roles are shared by all
+-- subgame-using game engines. The ninth is never read by the pen and appears
+-- (as unusedplaylist) only when non-empty.
 data SubGameYaml = SubGameYaml
-    { sgUnknown :: String
-    , sgOids1 :: OIDListYaml
-    , sgOids2 :: OIDListYaml
-    , sgOids3 :: OIDListYaml
-    , sgPlaylist :: [PlayListListYaml]
+    { sgHeader :: String
+    , sgTargetOids :: OIDListYaml
+    , sgDecoyOids :: OIDListYaml
+    , sgAllOids :: OIDListYaml
+    , sgAnnounce :: PlayListListYaml
+    , sgCorrect :: PlayListListYaml
+    , sgWrong :: PlayListListYaml
+    , sgNotInGame :: PlayListListYaml
+    , sgAlreadyFound :: PlayListListYaml
+    , sgHints :: PlayListListYaml
+    , sgRoundComplete :: PlayListListYaml
+    , sgSolution :: PlayListListYaml
+    , sgUnusedPlaylist :: Maybe PlayListListYaml
     }
     deriving Generic
 
@@ -333,21 +345,32 @@ oidList2Yaml :: [OID] -> OIDListYaml
 oidList2Yaml = unwords . map show
 
 subGame2Yaml :: SubGame -> SubGameYaml
-subGame2Yaml (SubGame u o1 o2 o3 pl) = SubGameYaml
-    { sgUnknown = prettyHex u
-    , sgOids1 = oidList2Yaml o1
-    , sgOids2 = oidList2Yaml o2
-    , sgOids3 = oidList2Yaml o3
-    , sgPlaylist = map playListList2Yaml pl
-    }
+subGame2Yaml (SubGame u o1 o2 o3 pl) = case pl of
+    [a, c, w, n, f, h, r, sol, u9] -> SubGameYaml
+        { sgHeader = prettyHex u
+        , sgTargetOids = oidList2Yaml o1
+        , sgDecoyOids = oidList2Yaml o2
+        , sgAllOids = oidList2Yaml o3
+        , sgAnnounce = playListList2Yaml a
+        , sgCorrect = playListList2Yaml c
+        , sgWrong = playListList2Yaml w
+        , sgNotInGame = playListList2Yaml n
+        , sgAlreadyFound = playListList2Yaml f
+        , sgHints = playListList2Yaml h
+        , sgRoundComplete = playListList2Yaml r
+        , sgSolution = playListList2Yaml sol
+        , sgUnusedPlaylist =
+            if null u9 then Nothing else Just (playListList2Yaml u9)
+        }
+    pls -> error $ printf "subGame2Yaml: expected 9 playlists, got %d" (length pls)
 
 game2gameYaml :: Game -> GameYaml
 game2gameYaml CommonGame {..} = CommonGameYaml
         { gyGameType                 = gGameType
         , gyRounds                   = gRounds
-        , gyUnknownC                 = gUnknownC
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -365,10 +388,10 @@ game2gameYaml Game6 {..} = Game6Yaml
         , gyBonusSubgameCount        = gBonusSubgameCount
         , gyBonusRounds              = gBonusRounds
         , gyBonusTarget              = gBonusTarget
-        , gyUnknownI                 = gUnknownI
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyUnknownQ                 = gUnknownQ
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyBonusEarlyRounds         = gBonusEarlyRounds
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -388,9 +411,9 @@ game2gameYaml Game6 {..} = Game6Yaml
         }
 game2gameYaml Game7 {..} = Game7Yaml
         { gyRounds                   = gRounds
-        , gyUnknownC                 = gUnknownC
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -406,9 +429,9 @@ game2gameYaml Game7 {..} = Game7Yaml
         }
 game2gameYaml Game8 {..} = Game8Yaml
         { gyRounds                   = gRounds
-        , gyUnknownC                 = gUnknownC
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -427,9 +450,9 @@ game2gameYaml Game8 {..} = Game8Yaml
         }
 game2gameYaml Game9 {..} = Game9Yaml
         { gyRounds                   = gRounds
-        , gyUnknownC                 = gUnknownC
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -445,9 +468,9 @@ game2gameYaml Game9 {..} = Game9Yaml
         }
 game2gameYaml Game10 {..} = Game10Yaml
         { gyRounds                   = gRounds
-        , gyUnknownC                 = gUnknownC
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -463,9 +486,9 @@ game2gameYaml Game10 {..} = Game10Yaml
         }
 game2gameYaml Game16 {..} = Game16Yaml
         { gyRounds                   = gRounds
-        , gyUnknownC                 = gUnknownC
+        , gyAllNeeded                = gAllNeeded /= 0
         , gyEarlyRounds              = gEarlyRounds
-        , gyRepeatLastMedia          = gRepeatLastMedia
+        , gyRepeatOID                = gRepeatOID
         , gyUnknownX                 = gUnknownX
         , gyUnknownW                 = gUnknownW
         , gyUnknownV                 = gUnknownV
@@ -495,22 +518,23 @@ oidListFromYaml :: OIDListYaml -> [OID]
 oidListFromYaml = map read . words
 
 subGameFromYaml :: SubGameYaml -> WithFileNames SubGame
-subGameFromYaml (SubGameYaml u o1 o2 o3 pl) = (\x -> SubGame
-    { sgUnknown = either error id $ parseOneLinePure parsePrettyHex "unknown" u
-    , sgOids1 = oidListFromYaml o1
-    , sgOids2 = oidListFromYaml o2
-    , sgOids3 = oidListFromYaml o3
-    , sgPlaylist = x
-    }) <$> traverse playListListFromYaml pl
+subGameFromYaml (SubGameYaml u o1 o2 o3 a c w n f h r sol u9) = (\pls -> SubGame
+    { sgHeader = either error id $ parseOneLinePure parsePrettyHex "header" u
+    , sgTargetOids = oidListFromYaml o1
+    , sgDecoyOids = oidListFromYaml o2
+    , sgAllOids = oidListFromYaml o3
+    , sgPlaylist = pls
+    }) <$> traverse playListListFromYaml
+        [a, c, w, n, f, h, r, sol, fromMaybe (OptArray []) u9]
 
 
 gameYaml2Game :: GameYaml -> WithFileNames Game
 gameYaml2Game CommonGameYaml {..} = pure CommonGame
         <*> pure gyGameType
         <*> pure gyRounds
-        <*> pure gyUnknownC
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyRepeatLastMedia
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV
@@ -527,10 +551,10 @@ gameYaml2Game Game6Yaml {..} = pure Game6
         <*> pure gyBonusSubgameCount
         <*> pure gyBonusRounds
         <*> pure gyBonusTarget
-        <*> pure gyUnknownI
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyUnknownQ
-        <*> pure gyRepeatLastMedia
+        <*> pure gyBonusEarlyRounds
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV
@@ -549,9 +573,9 @@ gameYaml2Game Game6Yaml {..} = pure Game6
         <*> pure gyBonusSubgameIds
 gameYaml2Game Game7Yaml {..} = pure Game7
         <*> pure gyRounds
-        <*> pure gyUnknownC
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyRepeatLastMedia
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV
@@ -566,9 +590,9 @@ gameYaml2Game Game7Yaml {..} = pure Game7
         <*> pure gySubgameGroups
 gameYaml2Game Game8Yaml {..} = pure Game8
         <*> pure gyRounds
-        <*> pure gyUnknownC
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyRepeatLastMedia
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV
@@ -586,9 +610,9 @@ gameYaml2Game Game8Yaml {..} = pure Game8
         <*> playListListFromYaml gyGameSelectErrors2
 gameYaml2Game Game9Yaml {..} = pure Game9
         <*> pure gyRounds
-        <*> pure gyUnknownC
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyRepeatLastMedia
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV
@@ -603,9 +627,9 @@ gameYaml2Game Game9Yaml {..} = pure Game9
         <*> traverse playListListFromYaml gyExtraPlayLists
 gameYaml2Game Game10Yaml {..} = pure Game10
         <*> pure gyRounds
-        <*> pure gyUnknownC
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyRepeatLastMedia
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV
@@ -620,9 +644,9 @@ gameYaml2Game Game10Yaml {..} = pure Game10
         <*> traverse playListListFromYaml gyExtraPlayLists
 gameYaml2Game Game16Yaml {..} = pure Game16
         <*> pure gyRounds
-        <*> pure gyUnknownC
+        <*> pure (fromIntegral (fromEnum gyAllNeeded))
         <*> pure gyEarlyRounds
-        <*> pure gyRepeatLastMedia
+        <*> pure gyRepeatOID
         <*> pure gyUnknownX
         <*> pure gyUnknownW
         <*> pure gyUnknownV

--- a/src/TipToiYamlAux.hs
+++ b/src/TipToiYamlAux.hs
@@ -6,6 +6,7 @@ import Data.Char
 gameYamlOptions = defaultOptions
     { fieldLabelModifier = map fix . map toLower . drop 2
     , allNullaryToStringTag = True
+    , omitNothingFields = True -- for the optional unusedplaylist
     }
        where fix '_' = '-'
              fix c   = c

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -117,13 +117,23 @@ data TipToiFile = TipToiFile
 type PlayListList = [PlayList]
 type GameId = Word16
 
+-- Game-record fields with meanings established by firmware analysis (they hold
+-- across all game types that use them):
+--   * gAllNeeded  : the find-all-targets flag: 0 = the first correct tap completes
+--                   the round, 1 = every target OID of the subgame must be found
+--                   (word "c" of the common layout, word "i" of the type-6 layout)
+--   * gRepeatOID  : a control OID that replays the current prompt or hint
+--   * gEarlyRounds / gBonusEarlyRounds : round number at which the round
+--                   announcement switches from the round-start to the
+--                   later-round-start playlists (0 = no announcements)
+-- See the game table section in GME-Format.md.
 data Game =
     CommonGame
         { gGameType                 :: Word16
         , gRounds                   :: Word16
-        , gUnknownC                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -141,10 +151,10 @@ data Game =
         , gBonusSubgameCount        :: Word16
         , gBonusRounds              :: Word16
         , gBonusTarget              :: Word16
-        , gUnknownI                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gUnknownQ                 :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gBonusEarlyRounds         :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -164,9 +174,9 @@ data Game =
         }
     | Game7
         { gRounds                   :: Word16
-        , gUnknownC                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -182,9 +192,9 @@ data Game =
         }
     | Game8
         { gRounds                   :: Word16
-        , gUnknownC                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -203,9 +213,9 @@ data Game =
         }
     | Game9
         { gRounds                   :: Word16
-        , gUnknownC                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -221,9 +231,9 @@ data Game =
         }
     | Game10
         { gRounds                   :: Word16
-        , gUnknownC                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -239,9 +249,9 @@ data Game =
         }
     | Game16
         { gRounds                   :: Word16
-        , gUnknownC                 :: Word16
+        , gAllNeeded                :: Word16
         , gEarlyRounds              :: Word16
-        , gRepeatLastMedia          :: Word16
+        , gRepeatOID                :: Word16
         , gUnknownX                 :: Word16
         , gUnknownW                 :: Word16
         , gUnknownV                 :: Word16
@@ -272,11 +282,15 @@ gameType Game253 {} = 253
 
 type OID = Word16
 
+-- sgTargetOids are the correct answers, sgDecoyOids known-wrong answers with
+-- dedicated feedback, sgAllOids the subgame's remaining active OIDs (hint
+-- feedback). sgHeader holds ten 16-bit words tuning feedback selection and
+-- wrong-tap limits. See the game table section in GME-Format.md.
 data SubGame = SubGame
-    { sgUnknown :: B.ByteString
-    , sgOids1 :: [OID]
-    , sgOids2 :: [OID]
-    , sgOids3 :: [OID]
+    { sgHeader :: B.ByteString
+    , sgTargetOids :: [OID]
+    , sgDecoyOids :: [OID]
+    , sgAllOids :: [OID]
     , sgPlaylist :: [PlayListList]
     }
     deriving Show

--- a/testsuite/expected/downloaded/Alle meine Tiere.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Alle meine Tiere.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-b5f23fdb30f493cb3031bea51949675c  output/downloaded/Alle meine Tiere.gme.yaml
+935c364ce9548da6aff12fa4ddd02124  output/downloaded/Alle meine Tiere.gme.yaml

--- a/testsuite/expected/downloaded/Dein Koerper und Du.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Dein Koerper und Du.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-1c821a8f44b17542233093368f9df8fd  output/downloaded/Dein Koerper und Du.gme.yaml
+c4825a01e4f68a1216342cd17b91dcba  output/downloaded/Dein Koerper und Du.gme.yaml

--- a/testsuite/expected/downloaded/Duell-der-Superquizzer.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Duell-der-Superquizzer.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-af769fd7b07d9f387295496edbedde7a  output/downloaded/Duell-der-Superquizzer.gme.yaml
+dd5ad506e264301aa91db20eeb8aec6b  output/downloaded/Duell-der-Superquizzer.gme.yaml

--- a/testsuite/expected/downloaded/Expedition Wissen - Aegypten.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Expedition Wissen - Aegypten.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-800676217248caaeaed665d75b0e648f  output/downloaded/Expedition Wissen - Aegypten.gme.yaml
+76cada1c5a4b042e0b1e483a1028995e  output/downloaded/Expedition Wissen - Aegypten.gme.yaml

--- a/testsuite/expected/downloaded/Leserabe Drache.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Leserabe Drache.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-a37fd3fc2ae5b3921d2fca7c94042b84  output/downloaded/Leserabe Drache.gme.yaml
+7adf01177b63c74928ea7b1fc4b0cb93  output/downloaded/Leserabe Drache.gme.yaml

--- a/testsuite/expected/downloaded/Pocket Wissen - Baustellenfahrzeuge.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Pocket Wissen - Baustellenfahrzeuge.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-f32500e8e2c0db67b70b812265113687  output/downloaded/Pocket Wissen - Baustellenfahrzeuge.gme.yaml
+e70c546eaad3d44b0da370dbf918a37e  output/downloaded/Pocket Wissen - Baustellenfahrzeuge.gme.yaml

--- a/testsuite/expected/downloaded/Puzzle Ritterburg.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Puzzle Ritterburg.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-27fd3fcb5a0a359cdd8ebeb1bd5d4b62  output/downloaded/Puzzle Ritterburg.gme.yaml
+6c7ccab1f5328a5119d550397a49ac99  output/downloaded/Puzzle Ritterburg.gme.yaml

--- a/testsuite/expected/downloaded/Sprichst_Du_Englisch.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/Sprichst_Du_Englisch.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-2bc7972eb741ef9fd1cc2f2fcc299fa6  output/downloaded/Sprichst_Du_Englisch.gme.yaml
+5a15308f0272c545bfecf10fde5fafb0  output/downloaded/Sprichst_Du_Englisch.gme.yaml

--- a/testsuite/expected/downloaded/WWW Ritter.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/WWW Ritter.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-ab994c8c1bb11c453c1b23568a2ed695  output/downloaded/WWW Ritter.gme.yaml
+b40247ef2936d3c866a1c504dabb0cec  output/downloaded/WWW Ritter.gme.yaml

--- a/testsuite/expected/downloaded/WWW Weltatlas.gme.yaml.md5sum
+++ b/testsuite/expected/downloaded/WWW Weltatlas.gme.yaml.md5sum
@@ -1,1 +1,1 @@
-eea2ed519b65adab2ff0c043eeede158  output/downloaded/WWW Weltatlas.gme.yaml
+f12054215ed0395a44479d6845c786c8  output/downloaded/WWW Weltatlas.gme.yaml


### PR DESCRIPTION
Firmware analysis established what the built-in games do with several previously unknown fields of a GME game record, uniformly across the game types that use them. Rename them accordingly in the Haskell types, the YAML format and the explain/games output:

 * unknown (c) -> "all needed": the find-all-targets flag (0: the first correct tap completes the round; 1: every target OID must be found). It is 0 or 1 in all 818 game records of all 205 published GMEs, so the YAML field (allneeded) is a boolean. The type-6 layout keeps the same flag in a different word ("i"), which gets the same name;
 * unknown (q) -> "bonus early rounds": the bonus stage's early-rounds value (type 6);
 * repeat last media OID -> "repeat OID": a control OID that replays the current prompt or hint;
 * subgames: u/oids1/oids2/oids3 -> header / target oids (the correct answers) / decoy oids (known-wrong answers with dedicated feedback) / all oids (the remaining active OIDs, which get hint feedback);
 * the nine subgame playlists have fixed roles shared by all subgame-using game engines, and become individual named YAML fields: announce, correct, wrong, notingame, alreadyfound, hints, roundcomplete, solution. The ninth is never read by the pen but is populated in 711 of 5979 subgames of published GMEs, so it is preserved as an optional "unusedplaylist" (present only when non-empty).

The x/w/v words stay "unknown": they are read and discarded by every game handler, and their values vary across products, so any name would over-claim.

The expected md5sums of the testsuite's downloaded-GME yaml exports are regenerated for the renamed fields (info/lint outputs are unchanged).