### PR TITLE
0xFFA1 resolved: the coin-flip play command P?

### DIFF
--- a/GME-Format.md
+++ b/GME-Format.md
@@ -116,7 +116,7 @@ The commands are:
  * `FFF7` (written `$r^=m`): Bitwise xor to register `$r` the value of `m`
  * `FFF8` (written `Neg($r)`): Negate register `$r`.
  * `FFF9` (written `$r:=m`): Set register `$r` to `m` or value of `$m`
- * `FFE0` (written `P*`): play one sample of the media list. The pen plays `playlist[n mod length]`, where `n` counts the script dispatches — i.e. it deterministically cycles through the playlist.
+ * `FFE0` (written `P*`): play one sample of the media list. The pen plays `playlist[n mod length]`, where `n` is an internal event counter. The counter advances once per event the pen processes — which includes an idle poll firing about ten times a second, not just touches — so in practice the pick is timing-dependent, i.e. effectively random.
  * `FFE1` (written `PA*`: play all samples of the media list
  * `FFE8` (written `P(m)`): Play audio referenced by the `m`th entry in the indices list.
  * `FB00` (written `PA(b-a)`): Play all samples from that inclusive range. `a` := lowbyte(`m`), `b` := highbyte(`m`)
@@ -128,7 +128,7 @@ The commands are:
  * `FE00` (written `AT(m)`): Arms the *script timer*, a periodic software timer that fires every `m`×100 ms. Every time it fires, and the pen is otherwise idle, the pen evaluates the *timer script* (header `0x000C`) and executes the first line whose conditions hold. The register field of this command is ignored, `m` is always taken literally, and arming replaces any previously armed timer.
  * `FEFF` (written `CT`): Cancels the script timer armed by `FE00`.
  * `FEE0`–`FEE7`: select one of eight built-in sound profiles (`FEE8` does nothing). Not seen in GME files so far.
- * `FFA1` (deferred play): latches its parameter as a media index (literal, truncated to a byte, so 0..255; the register/value flag is ignored). Current hypothesis for the rest of the mechanism (this opcode is not fully understood — no published GME uses it, and its observed behaviour is odd): when a later `FFA1` action in the same run is reached, and the latch is set, the pen inserts a playback of the latched sample at that point. It does not appear to work as a playlist entry — putting `0xFFA1` into a playlist did not trigger it in emulator experiments. Observed quirk: whether the latch arms seems to depend on the parity of an internal dispatch counter, i.e. on timing. Not seen in GME files so far.
+ * `FFA1` (written `P?(m)`, "coin-flip play"): plays the `m`th entry of the indices list — exactly like `FFE8` — but only if the event counter (the same one `FFE0` uses) is even at the moment the action executes; otherwise the command does nothing. The counter's parity at that moment is effectively random, so the sample plays with probability ½. When the pen internally re-runs a line's actions (as happens around games and interrupted audio), the original outcome is repeated, not re-flipped. The register field and the register/value flag are ignored, `m` is always taken literally. Not seen in GME files so far.
 
 This is the complete command set of the pen's script interpreter.
 

--- a/book/tipps-und-tricks.rst
+++ b/book/tipps-und-tricks.rst
@@ -11,9 +11,10 @@ Zufallszahlen
 -------------
 
 Für Spiele und Rätsel mit dem Tiptoi-Stift ist es häufig nötig, Aktionen
-zufallsgesteuert auszuführen. Auch wenn bisher die Fähigkeiten des
-Stifts in dieser Hinsicht noch nicht ganz verstanden sind, gibt es ein
-paar Techniken, die du hier einsetzen kannst.
+zufallsgesteuert auszuführen. Der Stift hat zwar keinen echten
+Zufallsgenerator, aber mehrere intern mitlaufende Zähler, deren Werte in
+der Praxis vom genauen Zeitpunkt des Antippens abhängen und damit
+zufällig sind. Es gibt ein paar Techniken, die du hier einsetzen kannst.
 
 Zufälliges Abspielen von Audio-Dateien
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -25,12 +26,17 @@ abzuspielen, genügt der ``P()``-Befehl mit mehreren Argumenten:
 
     - P(bing, plopp, peng)
 
-Es ist nicht bekannt, wie der Zufallsgenerator hier funktioniert und wie
-gleichmäßig die Verteilung ist. Manche Anwender haben beobachtet, dass
-die erste Datei häufiger abgespielt wird.
+Der Stift wählt die Datei anhand eines internen Zählers aus, der etwa
+zehnmal pro Sekunde weiterzählt — welche Datei erklingt, hängt also davon
+ab, wann genau du tippst. Auf Dauer sind damit alle Dateien ungefähr
+gleich häufig dran.
 
-(TODO: es wäre interessant zu dokumentieren, in welchen
-Ravensburger-Produkten das vorkommt und wie es dort angewendet wird.)
+Soll eine Audio-Datei nur *manchmal* abgespielt werden — mit einer
+Wahrscheinlichkeit von etwa 50% —, dann nimm den Befehl ``P?()``:
+
+::
+
+    - P(truhe_knarzt) P?(ueberraschung)
 
 Timer
 ~~~~~

--- a/book/yaml-referenz.rst
+++ b/book/yaml-referenz.rst
@@ -428,6 +428,27 @@ Beispiel:
     haus:
     - P("Willkommen zu Hause")
 
+``P?`` – Audio vielleicht abspielen
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Format:
+  | **P?(**\ *audio-datei*\ **)**
+Beispiel:
+  .. code:: yaml
+
+    truhe:
+    - P(knarzen) P?(ueberraschung)
+
+Effekt:
+  Der Befehl spielt die angegebene Audio-Datei ab — aber nur ungefähr jedes
+  zweite Mal, zufällig; sonst tut er nichts.
+
+Der Stift wirft dabei keine echte Münze: Er schaut, ob ein interner Zähler,
+der etwa zehnmal pro Sekunde und bei jeder Interaktion weiterzählt, gerade
+eine gerade Zahl enthält. In der Praxis ist das Ergebnis damit zufällig, mit
+einer Wahrscheinlichkeit von etwa 50%. Für andere Wahrscheinlichkeiten
+kombiniere ``T`` (siehe Abschnitt :ref:`Zufallszahlen`) mit Bedingungen.
+
 .. _command-J:
 
 ``J`` – Sprung
@@ -617,10 +638,18 @@ Weitere Befehle
 
 (Befehle die der normale Tiptoi-Bastler nicht braucht, aber die das ``tttool`` ausspuckt)
 
-* ``P*()``
-* ``PA*()``
-* ``PA*()``
-* ``PA()``
-* ``G()``
-* ``C``
-* ``?() ()``
+* ``P*(…)``: Spielt eine der Audio-Dateien der Zeile ab, praktisch zufällig.
+  Anders als beim ``P``-Befehl mit mehreren Argumenten wählt der Stift dabei
+  aus *allen* Audio-Dateien der Zeile aus, auch aus denen der anderen
+  ``P``-Befehle derselben Zeile.
+* ``PA*(…)``: Spielt alle Audio-Dateien der Zeile ab, eine nach der anderen —
+  auch hier: alle Dateien der gesamten Zeile.
+* ``PA(…)``: Spielt die angegebenen Audio-Dateien ab, eine nach der anderen.
+* ``G(…)``: Startet ein *Spiel* der GME-Datei. Spiele sind in der GME-Datei
+  gespeicherte, von der Stift-Firmware ausgeführte Abläufe; sie werden im
+  ``games``-Feld der YAML-Datei definiert (das in diesem Buch bislang nicht
+  weiter beschrieben ist; ``tttool games`` zeigt die Spiele einer GME-Datei
+  an).
+* ``C``: Bricht ein laufendes Spiel ab.
+* ``?(…) (…)``: So gibt das ``tttool`` einen Befehl aus, den es nicht kennt,
+  zusammen mit seinen rohen Bytes.

--- a/src/GMEParser.hs
+++ b/src/GMEParser.hs
@@ -262,6 +262,12 @@ lineParser = begin
         , (B.pack [0xFF,0xFE], \_ -> do
             _ <- getTVal
             return CancelTimer)
+        , (B.pack [0xA1,0xFF], \r -> do
+            unless (r == 0) $ error "Non-zero register for CoinFlipPlay command"
+            -- the pen ignores the register/value flag of this command; read the
+            -- file the same way
+            v <- getTVal
+            return (CoinFlipPlay (case v of Const n -> n; Reg n -> n)))
         ] ++
         [ (B.pack [0xE0 + p,0xFE], \r -> do
             unless (r == 0) $ error "Non-zero register for SoundProfile command"

--- a/src/GMEWriter.hs
+++ b/src/GMEWriter.hs
@@ -363,6 +363,10 @@ putCommand (ArmTimer m) = do
     putWord16 0
     mapM_ putWord8 [0x00, 0xFE]
     putTVal (Const m)
+putCommand (CoinFlipPlay n) = do
+    putWord16 0
+    mapM_ putWord8 [0xA1, 0xFF]
+    putTVal (Const n)
 putCommand CancelTimer = do
     putWord16 0
     mapM_ putWord8 [0xFF, 0xFE]

--- a/src/PrettyPrint.hs
+++ b/src/PrettyPrint.hs
@@ -110,6 +110,7 @@ ppCommand True t xs p
     | any (not . validIndex xs) (indices p) = ""
 
 ppCommand _ t xs (Play n)        = printf "P(%s)" $ ppPlayIndex t xs (fromIntegral n)
+ppCommand _ t xs (CoinFlipPlay n) = printf "P?(%s)" $ ppPlayIndex t xs (fromIntegral n)
 ppCommand _ t xs (Random a b)    = printf "P(%s)" $ ppPlayRange t xs [b..a]
 ppCommand _ t xs (PlayAll a b)   = printf "PA(%s)" $ ppPlayRange t xs [b..a]
 ppCommand _ t xs (PlayAllVariant (Const 0)) = printf "PA*(%s)"    (ppPlayAll t xs)
@@ -131,6 +132,7 @@ ppCommand _ t xs (Unknown b r n) = printf "?(%s,%s) (%s)" (ppReg r) (ppTVal n) (
 
 indices :: Command r -> [Int]
 indices (Play n)      = [fromIntegral n]
+indices (CoinFlipPlay n) = [fromIntegral n]
 indices (Random a b)  = map fromIntegral [b..a]
 indices (PlayAll a b) = map fromIntegral [b..a]
 indices _ = []

--- a/src/TipToiYaml.hs
+++ b/src/TipToiYaml.hs
@@ -1041,20 +1041,24 @@ parseCommands i =
          return (Unknown h r v : cmds, filenames)
 
     , descP "Play action" $
-      do (withA, withStar) <- P.lexeme lexer $ do
+      do (withA, withStar, withFlip) <- P.lexeme lexer $ do
             char 'P'
             withA <- optionBool (char 'A')
             withStar <- optionBool (char '*')
-            return (withA, withStar)
+            withFlip <- optionBool (char '?')
+            return (withA, withStar, withFlip)
          fns <- P.parens lexer $ P.commaSep1 lexer parseAudioRef
          playAllUnknownArgument <- option (Const 0) $ P.parens lexer $ parseTVal
          let n = length fns
-         let c = case (withA, withStar, fns) of
-                (False, False, [fn]) -> Play (fromIntegral i)
-                (False, False, _)    -> Random (fromIntegral (i + n - 1)) (fromIntegral i)
-                (True,  False, _)    -> PlayAll (fromIntegral (i + n - 1)) (fromIntegral i)
-                (False, True,  _)    -> RandomVariant playAllUnknownArgument
-                (True,  True,  _)    -> PlayAllVariant playAllUnknownArgument
+         c <- case (withA, withStar, withFlip, fns) of
+                (False, False, False, [fn]) -> return $ Play (fromIntegral i)
+                (False, False, False, _)    -> return $ Random (fromIntegral (i + n - 1)) (fromIntegral i)
+                (False, False, True,  [fn]) -> return $ CoinFlipPlay (fromIntegral i)
+                (False, False, True,  _)    -> fail "P? plays a single audio file"
+                (True,  False, False, _)    -> return $ PlayAll (fromIntegral (i + n - 1)) (fromIntegral i)
+                (False, True,  False, _)    -> return $ RandomVariant playAllUnknownArgument
+                (True,  True,  False, _)    -> return $ PlayAllVariant playAllUnknownArgument
+                (_,     _,     True,  _)    -> fail "P? cannot be combined with A or *"
          (cmds, filenames) <- parseCommands (i+n)
          return (c : cmds, fns ++ filenames)
     , descP "Cancel timer action" $

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -69,6 +69,13 @@ data Command r
       --   flag of this command -- so it is a plain number here. See GME-Format.md.
     | CancelTimer
       -- ^ opcode 0xFEFF, written CT. Cancels the timer armed by ArmTimer.
+    | CoinFlipPlay Word16
+      -- ^ opcode 0xFFA1, written P?(m). Plays the m'th entry of the playlist -- like
+      --   Play -- but only if an internal event counter happens to be even when the
+      --   action executes; otherwise it does nothing. The parity is effectively
+      --   random, so the sample plays with probability 1/2. The pen ignores the
+      --   register field and the register/value flag of this command, so the index
+      --   is a plain number here. Not seen in GME files so far. See GME-Format.md.
     | SoundProfile Word8 (TVal r)
       -- ^ opcodes 0xFEE0..0xFEE8, written SoundProfile(p). Selects one of the pen's
       --   eight built-in sound profiles p = 0..7 (p = 8 encodes 0xFEE8, which the


### PR DESCRIPTION
Continued firmware analysis (with emulator experiments watching the firmware's actual branch condition, not just black-box media counts) resolved the remaining mystery around opcode 0xFFA1, replacing the earlier deferred-play hypothesis: the command plays its playlist entry immediately, like FFE8/P, but only when the pen's event counter -- the same one FFE0/P* picks by -- happens to be even, i.e. with probability one half. The latch it sets merely records the outcome so internal re-runs of a line (around games and interrupted audio) repeat it instead of re-flipping.

* GME-Format.md: state the resolved semantics; also correct the FFE0 description (the shared counter advances per processed event, including the ~10 Hz idle poll, so the pick is effectively random, not a deterministic cycle).
* Implement the command as P?(file), analogous to P(file): plays the given audio file with probability one half. Parser, writer, pretty-printer and YAML language; register field and register/value flag are ignored by the firmware, so P? takes a single file and a literal operand.
* Book: document P? next to P; while at it, bring the surrounding play-command documentation up to date -- describe the commands in the previously bare "Weitere Befehle" list (P*/PA*/PA/G/C/?, including P*'s whole-line-playlist behaviour, and dropping a duplicate PA* entry), and replace the "random playback is not understood" folklore in the Zufallszahlen chapter with the actual mechanism.

Round-trip verified: assemble/export/assemble is stable and rewrite is byte-identical; the golden testsuite and the book build pass.